### PR TITLE
feat(server): add MCP roots support with env var fallback

### DIFF
--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -62,6 +62,7 @@ class MCPServer:
                                 if len(path_parts) >= 2 and path_parts[0] and path_parts[1]:
                                     return path_parts[0], path_parts[1]
                 except (subprocess.TimeoutExpired, FileNotFoundError, subprocess.CalledProcessError):
+                    # Git command failed - continue to env var fallback
                     pass
                 break
             if current.parent == current:


### PR DESCRIPTION
- Query MCP client for workspace roots via roots/list
- Search for .git in MCP roots first
- Fallback to GITHUB_REPOSITORY env var if roots not available
- Cache roots to avoid repeated requests
- Log detection method for debugging
- All 13 tests passing
